### PR TITLE
Fix: Component key is not arbitrary. 

### DIFF
--- a/shrike-examples/pipelines/experiments/demo_component_with_parameter.py
+++ b/shrike-examples/pipelines/experiments/demo_component_with_parameter.py
@@ -41,7 +41,7 @@ class ComponentWithParameterDemo(AMLPipelineHelper):
         """
 
         # helper functions below load the subgraph/component from registered or local version depending on your config.run.use_local
-        component_with_parameter = self.component_load("ComponentWithParameter")
+        component_with_parameter = self.component_load(<your-component-key>)
 
         # Here you should create an instance of a pipeline function (using your custom config dataclass)
         @dsl.pipeline(

--- a/shrike-problems/problems/pipelines-02.md
+++ b/shrike-problems/problems/pipelines-02.md
@@ -26,7 +26,8 @@ Then, implement the `main()` method to consume your newly introduced parameter. 
 ### Add you component to the component dictionary
 Open the [module_defaults.yaml](../../shrike-examples/pipelines/config/modules/module_defaults.yaml) file and add an entry for the new component following the example of the HelloWorldComponent.
 
-- `key` is how you will point to the component later on, in the experiment python file or in the command line when deciding which components should use the local version. You can choose any arbitrary value here.
+- `key` is how you will point to the component later on, in the experiment python file or in the command line when deciding which components should use the local version. You can choose any arbitrary value here. Later on, you need this key in [your experiment python file](../../shrike-examples/pipelines/experiments/demo_component_with_parameter.py)
+to load the component.
 - `name` must match the name you defined in the component specification file, as it will be used to retrieve the component if you use the remote version.
 - `version` can be left `null`.
 - `yaml` is the location of the component specification file.


### PR DESCRIPTION
Update README and demo_component_with_parameter.py to suggest using the same component key. Basically, the reader should understand that the component key is how the component will later be referenced.